### PR TITLE
feat: Add streamWithEvents with thinking state machine

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "react-native": "0.81.5",
         "react-native-keyboard-controller": "1.18.5",
         "react-native-nitro-mlx": "*",
-        "react-native-nitro-modules": "^0.31.10",
+        "react-native-nitro-modules": "^0.33.2",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -45,7 +45,7 @@
     },
     "package": {
       "name": "react-native-nitro-mlx",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "dependencies": {
         "zod": "^4.3.5",
       },
@@ -1514,7 +1514,7 @@
 
     "react-native-nitro-mlx": ["react-native-nitro-mlx@workspace:package"],
 
-    "react-native-nitro-modules": ["react-native-nitro-modules@0.31.10", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-hcvjTu9YJE9fMmnAUvhG8CxvYLpOuMQ/2eyi/S6GyrecezF6Rmk/uRQEL6v09BRFWA/xRVZNQVulQPS+2HS3mQ=="],
+    "react-native-nitro-modules": ["react-native-nitro-modules@0.33.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-ZlfOe6abODeHv/eZf8PxeSkrxIUhEKha6jaAAA9oXy7I6VPr7Ff4dUsAq3cyF3kX0L6qt2Dh9nzD2NdSsDwGpA=="],
 
     "react-native-reanimated": ["react-native-reanimated@4.1.5", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.2.1", "semver": "7.7.2" }, "peerDependencies": { "@babel/core": "^7.0.0-0", "react": "*", "react-native": "*", "react-native-worklets": ">=0.5.0" } }, "sha512-UA6VUbxwhRjEw2gSNrvhkusUq3upfD3Cv+AnB07V+kC8kpvwRVI+ivwY95ePbWNFkFpP+Y2Sdw1WHpHWEV+P2Q=="],
 
@@ -2067,6 +2067,8 @@
     "new-github-release-url/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
     "nitrogen/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "nitrogen/react-native-nitro-modules": ["react-native-nitro-modules@0.31.10", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-hcvjTu9YJE9fMmnAUvhG8CxvYLpOuMQ/2eyi/S6GyrecezF6Rmk/uRQEL6v09BRFWA/xRVZNQVulQPS+2HS3mQ=="],
 
     "nitrogen/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -389,6 +389,7 @@ export default function ChatScreen() {
             timeToFirstToken: event.stats.timeToFirstToken,
             totalTokens: event.stats.tokenCount,
             totalTime: event.stats.totalTime,
+            toolExecutionTime: event.stats.toolExecutionTime,
             timestamp: new Date(),
           })
           break

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -14,7 +14,7 @@ import {
   View,
 } from 'react-native'
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller'
-import { createTool, LLM, MLXModel, ModelManager } from 'react-native-nitro-mlx'
+import { createTool, LLM, MLXModel, ModelManager, type StreamEvent } from 'react-native-nitro-mlx'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { z } from 'zod'
 import { useBenchmark } from '../components/benchmark-context'
@@ -60,13 +60,20 @@ const weatherTool = createTool({
   },
 })
 
-type ToolCallStatus = {
+type ThinkingBlockData = {
+  type: 'thinking'
+  content: string
+}
+
+type ToolCallBlockData = {
+  type: 'tool_call'
+  id?: string
   name: string
   args: Record<string, unknown>
   completed?: boolean
 }
 
-type ToolCallsStatus = ToolCallStatus[]
+type MessageBlock = ThinkingBlockData | ToolCallBlockData
 
 function parseThinkingBlocks(text: string): { thinking: string; content: string } {
   const thinkRegex = /<think>([\s\S]*?)<\/think>/g
@@ -90,13 +97,13 @@ function parseThinkingBlocks(text: string): { thinking: string; content: string 
 type Message = {
   id: string
   content: string
-  thinking?: string
-  isThinking?: boolean
+  blocks?: MessageBlock[]
+  currentThinking?: string
+  isCurrentlyThinking?: boolean
   isUser: boolean
-  toolCalls?: ToolCallsStatus
 }
 
-const ToolCallBlock = ({ toolCall }: { toolCall: ToolCallStatus }) => {
+const ToolCallBlock = ({ toolCall }: { toolCall: ToolCallBlockData }) => {
   const [expanded, setExpanded] = useState(false)
   const colorScheme = useColorScheme()
 
@@ -140,7 +147,7 @@ const ToolCallBlock = ({ toolCall }: { toolCall: ToolCallStatus }) => {
   )
 }
 
-const ThinkingBlock = ({ thinking }: { thinking: string }) => {
+const ThinkingBlock = ({ thinking, isStreaming }: { thinking: string; isStreaming?: boolean }) => {
   const [expanded, setExpanded] = useState(false)
   const colorScheme = useColorScheme()
   const textColor = colorScheme === 'dark' ? '#aaa' : '#666'
@@ -156,6 +163,7 @@ const ThinkingBlock = ({ thinking }: { thinking: string }) => {
         <Text style={[styles.thinkingLabel, { color: textColor }]}>
           {expanded ? '▼' : '▶'} Thinking
         </Text>
+        {isStreaming && <ActivityIndicator size="small" color="#888" style={{ marginLeft: 8 }} />}
       </View>
       {expanded && (
         <Text style={[styles.thinkingText, { color: textColor }]}>{thinking}</Text>
@@ -164,7 +172,7 @@ const ThinkingBlock = ({ thinking }: { thinking: string }) => {
   )
 }
 
-const MessageItem = ({ content, thinking, isThinking, isUser, toolCalls }: Message) => {
+const MessageItem = ({ content, blocks, currentThinking, isCurrentlyThinking, isUser }: Message) => {
   const colorScheme = useColorScheme()
   const textColor = colorScheme === 'dark' ? 'white' : 'black'
 
@@ -178,20 +186,18 @@ const MessageItem = ({ content, thinking, isThinking, isUser, toolCalls }: Messa
 
   return (
     <View style={styles.message}>
-      {isThinking && !content && (!toolCalls || toolCalls.length === 0) && (
-        <View style={styles.thinkingIndicator}>
-          <ActivityIndicator size="small" color="#888" />
-          <Text style={[styles.thinkingIndicatorText, { color: textColor }]}>
-            Thinking...
-          </Text>
-        </View>
+      {blocks?.map((block, index) =>
+        block.type === 'thinking' ? (
+          <ThinkingBlock key={`block-${index}`} thinking={block.content} />
+        ) : (
+          <ToolCallBlock key={`block-${index}`} toolCall={block} />
+        ),
       )}
-      {thinking && <ThinkingBlock thinking={thinking} />}
-      {toolCalls?.map((toolCall, index) => (
-        <ToolCallBlock key={`${toolCall.name}-${index}`} toolCall={toolCall} />
-      ))}
-      {content ? (
-        <Text style={[styles.messageText, { color: textColor }]}>{content}</Text>
+      {isCurrentlyThinking && (
+        <ThinkingBlock thinking={currentThinking || 'Processing...'} isStreaming />
+      )}
+      {content?.trim() ? (
+        <Text style={[styles.messageText, { color: textColor }]}>{content.trim()}</Text>
       ) : null}
     </View>
   )
@@ -279,8 +285,7 @@ export default function ChatScreen() {
     const tempAssistantMessage: Message = {
       id: assistantMessageId,
       content: '',
-      thinking: '',
-      isThinking: false,
+      blocks: [],
       isUser: false,
     }
 
@@ -293,81 +298,105 @@ export default function ChatScreen() {
     inputRef.current?.blur()
     setIsGenerating(true)
 
-    let fullText = ''
-    let accumulatedThinking = ''
+    let content = ''
+    let currentThinking = ''
 
-    try {
-      await LLM.stream(
-        currentPrompt,
-        token => {
-          if (token === '\u200B') {
-            const { thinking } = parseThinkingBlocks(fullText)
-            if (thinking) {
-              accumulatedThinking = thinking
-            }
-            fullText = ''
-            return
-          }
-
-          fullText += token
-
-          const hasUnclosedThink =
-            fullText.includes('<think>') &&
-            fullText.split('<think>').length > fullText.split('</think>').length
-
-          const { thinking, content: parsedContent } = parseThinkingBlocks(fullText)
-          const content = hasUnclosedThink
-            ? parsedContent.replace(/<think>[\s\S]*$/, '').trim()
-            : parsedContent
-          const combinedThinking = accumulatedThinking
-            ? `${accumulatedThinking}\n\n${thinking}`.trim()
-            : thinking
-
+    const handleEvent = (event: StreamEvent) => {
+      switch (event.type) {
+        case 'thinking_start':
+          currentThinking = ''
           setMessages(prev =>
             prev.map(msg =>
               msg.id === assistantMessageId
-                ? {
-                    ...msg,
-                    thinking: combinedThinking || msg.thinking,
-                    content,
-                    isThinking: hasUnclosedThink,
-                  }
+                ? { ...msg, currentThinking: '', isCurrentlyThinking: true }
                 : msg,
             ),
           )
-        },
-        ({ allToolCalls }) => {
-          const toolCalls = allToolCalls.map(tc => ({
-            name: tc.name,
-            args: tc.arguments,
-          }))
+          break
+
+        case 'thinking_chunk':
+          currentThinking += event.chunk
           setMessages(prev =>
             prev.map(msg =>
-              msg.id === assistantMessageId ? { ...msg, toolCalls } : msg,
+              msg.id === assistantMessageId ? { ...msg, currentThinking } : msg,
             ),
           )
-        },
-      )
+          break
 
-      setMessages(prev =>
-        prev.map(msg =>
-          msg.id === assistantMessageId && msg.toolCalls
-            ? {
+        case 'thinking_end':
+          setMessages(prev =>
+            prev.map(msg => {
+              if (msg.id !== assistantMessageId) return msg
+              const thinkingBlock: ThinkingBlockData = { type: 'thinking', content: event.content }
+              return {
                 ...msg,
-                toolCalls: msg.toolCalls.map(tc => ({ ...tc, completed: true })),
+                blocks: [...(msg.blocks || []), thinkingBlock],
+                currentThinking: undefined,
+                isCurrentlyThinking: false,
               }
-            : msg,
-        ),
-      )
+            }),
+          )
+          break
 
-      const stats = LLM.getLastGenerationStats()
-      addResult({
-        tokensPerSecond: stats.tokensPerSecond,
-        timeToFirstToken: stats.timeToFirstToken,
-        totalTokens: stats.tokenCount,
-        totalTime: stats.totalTime,
-        timestamp: new Date(),
-      })
+        case 'token':
+          content += event.token
+          setMessages(prev =>
+            prev.map(msg =>
+              msg.id === assistantMessageId ? { ...msg, content } : msg,
+            ),
+          )
+          break
+
+        case 'tool_call_start':
+          setMessages(prev =>
+            prev.map(msg => {
+              if (msg.id !== assistantMessageId) return msg
+              const toolBlock: ToolCallBlockData = {
+                type: 'tool_call',
+                id: event.id,
+                name: event.name,
+                args: JSON.parse(event.arguments),
+                completed: false,
+              }
+              return {
+                ...msg,
+                blocks: [...(msg.blocks || []), toolBlock],
+              }
+            }),
+          )
+          break
+
+        case 'tool_call_completed':
+        case 'tool_call_failed':
+          setMessages(prev =>
+            prev.map(msg => {
+              if (msg.id !== assistantMessageId || !msg.blocks) return msg
+              return {
+                ...msg,
+                blocks: msg.blocks.map(block =>
+                  block.type === 'tool_call' && block.id === event.id
+                    ? { ...block, completed: true }
+                    : block,
+                ),
+              }
+            }),
+          )
+          break
+
+        case 'generation_end':
+          addResult({
+            tokensPerSecond: event.stats.tokensPerSecond,
+            timeToFirstToken: event.stats.timeToFirstToken,
+            totalTokens: event.stats.tokenCount,
+            totalTime: event.stats.totalTime,
+            timestamp: new Date(),
+          })
+          break
+      }
+    }
+
+    try {
+      await LLM.streamWithEvents(currentPrompt, handleEvent)
     } catch (error) {
       console.error('Error generating:', error)
     } finally {
@@ -396,11 +425,11 @@ export default function ChatScreen() {
     try {
       const history = LLM.getHistory()
       setMessages(prev => {
-        const toolCallsMap = new Map<number, ToolCallsStatus>()
+        const blocksMap = new Map<number, MessageBlock[]>()
         if (preserveToolCalls) {
           prev.forEach((msg, idx) => {
-            if (msg.toolCalls) {
-              toolCallsMap.set(idx, msg.toolCalls)
+            if (msg.blocks) {
+              blocksMap.set(idx, msg.blocks)
             }
           })
         }
@@ -415,13 +444,14 @@ export default function ChatScreen() {
           }
 
           const { thinking, content } = parseThinkingBlocks(msg.content)
+          const existingBlocks = blocksMap.get(index)
+          const blocks: MessageBlock[] = existingBlocks || (thinking ? [{ type: 'thinking', content: thinking }] : [])
 
           return {
             id: `history-${index}`,
             content,
-            thinking,
+            blocks,
             isUser: false,
-            toolCalls: toolCallsMap.get(index),
           }
         })
       })

--- a/example/app/settings-modal.tsx
+++ b/example/app/settings-modal.tsx
@@ -31,6 +31,7 @@ export default function SettingsModal() {
   const avgTtft = average(results, 'timeToFirstToken')
   const avgTokens = average(results, 'totalTokens')
   const avgTime = average(results, 'totalTime')
+  const avgToolTime = average(results, 'toolExecutionTime')
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: bgColor }]}>
@@ -82,6 +83,14 @@ export default function SettingsModal() {
                 </Text>
                 <Text style={[styles.metricLabel, { color: textColor }]}>avg time</Text>
               </View>
+              {avgToolTime > 0 && (
+                <View style={styles.metric}>
+                  <Text style={[styles.metricValue, { color: '#FF9500' }]}>
+                    {(avgToolTime / 1000).toFixed(1)}s
+                  </Text>
+                  <Text style={[styles.metricLabel, { color: textColor }]}>tool execution</Text>
+                </View>
+              )}
             </View>
           )}
         </View>

--- a/example/components/benchmark-context.tsx
+++ b/example/components/benchmark-context.tsx
@@ -5,6 +5,7 @@ export type BenchmarkResult = {
   timeToFirstToken: number
   totalTokens: number
   totalTime: number
+  toolExecutionTime: number
   timestamp: Date
 }
 

--- a/example/package.json
+++ b/example/package.json
@@ -25,7 +25,7 @@
     "react-native": "0.81.5",
     "react-native-keyboard-controller": "1.18.5",
     "react-native-nitro-mlx": "*",
-    "react-native-nitro-modules": "^0.31.10",
+    "react-native-nitro-modules": "^0.33.2",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",

--- a/package/ios/Sources/JSONHelpers.swift
+++ b/package/ios/Sources/JSONHelpers.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+func dictionaryToJson(_ dict: [String: Any]) -> String {
+    guard let data = try? JSONSerialization.data(withJSONObject: dict),
+          let json = String(data: data, encoding: .utf8) else {
+        return "{}"
+    }
+    return json
+}

--- a/package/ios/Sources/StreamEventEmitter.swift
+++ b/package/ios/Sources/StreamEventEmitter.swift
@@ -1,0 +1,99 @@
+import Foundation
+import NitroModules
+
+class StreamEventEmitter {
+    private let callback: (String) -> Void
+
+    init(callback: @escaping (String) -> Void) {
+        self.callback = callback
+    }
+
+    private func emit(_ dict: [String: Any]) {
+        callback(dictionaryToJson(dict))
+    }
+
+    private func timestamp() -> Double {
+        Date().timeIntervalSince1970 * 1000
+    }
+
+    func emitGenerationStart() {
+        emit([
+            "type": "generation_start",
+            "timestamp": timestamp()
+        ])
+    }
+
+    func emitToken(_ token: String) {
+        emit([
+            "type": "token",
+            "token": token
+        ])
+    }
+
+    func emitThinkingStart() {
+        emit([
+            "type": "thinking_start",
+            "timestamp": timestamp()
+        ])
+    }
+
+    func emitThinkingChunk(_ chunk: String) {
+        emit([
+            "type": "thinking_chunk",
+            "chunk": chunk
+        ])
+    }
+
+    func emitThinkingEnd(_ content: String) {
+        emit([
+            "type": "thinking_end",
+            "content": content,
+            "timestamp": timestamp()
+        ])
+    }
+
+    func emitToolCallStart(id: String, name: String, arguments: String) {
+        emit([
+            "type": "tool_call_start",
+            "id": id,
+            "name": name,
+            "arguments": arguments
+        ])
+    }
+
+    func emitToolCallExecuting(id: String) {
+        emit([
+            "type": "tool_call_executing",
+            "id": id
+        ])
+    }
+
+    func emitToolCallCompleted(id: String, result: String) {
+        emit([
+            "type": "tool_call_completed",
+            "id": id,
+            "result": result
+        ])
+    }
+
+    func emitToolCallFailed(id: String, error: String) {
+        emit([
+            "type": "tool_call_failed",
+            "id": id,
+            "error": error
+        ])
+    }
+
+    func emitGenerationEnd(content: String, stats: GenerationStats) {
+        emit([
+            "type": "generation_end",
+            "content": content,
+            "stats": [
+                "tokenCount": stats.tokenCount,
+                "tokensPerSecond": stats.tokensPerSecond,
+                "timeToFirstToken": stats.timeToFirstToken,
+                "totalTime": stats.totalTime
+            ]
+        ])
+    }
+}

--- a/package/ios/Sources/ThinkingStateMachine.swift
+++ b/package/ios/Sources/ThinkingStateMachine.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+class ThinkingStateMachine {
+    enum Output {
+        case token(String)
+        case thinkingStart
+        case thinkingChunk(String)
+        case thinkingEnd(String)
+    }
+
+    private enum State {
+        case idle
+        case bufferingOpenTag(String)
+        case inThinking
+        case bufferingCloseTag(String)
+    }
+
+    private var state: State = .idle
+    private var thinkingContent: String = ""
+
+    private let openTag = "<think>"
+    private let closeTag = "</think>"
+
+    func process(token: String) -> [Output] {
+        var outputs: [Output] = []
+        var remaining = token
+
+        while !remaining.isEmpty {
+            switch state {
+            case .idle:
+                outputs.append(contentsOf: processIdle(&remaining))
+
+            case .bufferingOpenTag(let buffer):
+                outputs.append(contentsOf: processBufferingOpenTag(buffer: buffer, remaining: &remaining))
+
+            case .inThinking:
+                outputs.append(contentsOf: processInThinking(&remaining))
+
+            case .bufferingCloseTag(let buffer):
+                outputs.append(contentsOf: processBufferingCloseTag(buffer: buffer, remaining: &remaining))
+            }
+        }
+
+        return outputs
+    }
+
+    func flush() -> [Output] {
+        var outputs: [Output] = []
+
+        switch state {
+        case .bufferingOpenTag(let buffer):
+            if !buffer.isEmpty {
+                outputs.append(.token(buffer))
+            }
+        case .bufferingCloseTag(let buffer):
+            if !buffer.isEmpty {
+                outputs.append(.thinkingChunk(buffer))
+            }
+            outputs.append(.thinkingEnd(thinkingContent + buffer))
+        case .inThinking:
+            outputs.append(.thinkingEnd(thinkingContent))
+        case .idle:
+            break
+        }
+
+        state = .idle
+        thinkingContent = ""
+        return outputs
+    }
+
+    private func processIdle(_ remaining: inout String) -> [Output] {
+        var outputs: [Output] = []
+
+        if let tagRange = remaining.range(of: openTag) {
+            let before = String(remaining[..<tagRange.lowerBound])
+            if !before.isEmpty {
+                outputs.append(.token(before))
+            }
+            outputs.append(.thinkingStart)
+            state = .inThinking
+            thinkingContent = ""
+            remaining = String(remaining[tagRange.upperBound...])
+        } else if let partialMatch = findPartialMatch(remaining, target: openTag) {
+            let before = String(remaining[..<partialMatch.range.lowerBound])
+            if !before.isEmpty {
+                outputs.append(.token(before))
+            }
+            state = .bufferingOpenTag(partialMatch.matched)
+            remaining = ""
+        } else {
+            outputs.append(.token(remaining))
+            remaining = ""
+        }
+
+        return outputs
+    }
+
+    private func processBufferingOpenTag(buffer: String, remaining: inout String) -> [Output] {
+        var outputs: [Output] = []
+        let combined = buffer + remaining
+
+        if let tagRange = combined.range(of: openTag) {
+            let before = String(combined[..<tagRange.lowerBound])
+            if !before.isEmpty {
+                outputs.append(.token(before))
+            }
+            outputs.append(.thinkingStart)
+            state = .inThinking
+            thinkingContent = ""
+            remaining = String(combined[tagRange.upperBound...])
+        } else if openTag.hasPrefix(combined) {
+            state = .bufferingOpenTag(combined)
+            remaining = ""
+        } else if let partialMatch = findPartialMatch(combined, target: openTag) {
+            let before = String(combined[..<partialMatch.range.lowerBound])
+            if !before.isEmpty {
+                outputs.append(.token(before))
+            }
+            state = .bufferingOpenTag(partialMatch.matched)
+            remaining = ""
+        } else {
+            outputs.append(.token(combined))
+            state = .idle
+            remaining = ""
+        }
+
+        return outputs
+    }
+
+    private func processInThinking(_ remaining: inout String) -> [Output] {
+        var outputs: [Output] = []
+
+        if let tagRange = remaining.range(of: closeTag) {
+            let before = String(remaining[..<tagRange.lowerBound])
+            if !before.isEmpty {
+                thinkingContent += before
+                outputs.append(.thinkingChunk(before))
+            }
+            outputs.append(.thinkingEnd(thinkingContent))
+            state = .idle
+            thinkingContent = ""
+            remaining = String(remaining[tagRange.upperBound...])
+        } else if let partialMatch = findPartialMatch(remaining, target: closeTag) {
+            let before = String(remaining[..<partialMatch.range.lowerBound])
+            if !before.isEmpty {
+                thinkingContent += before
+                outputs.append(.thinkingChunk(before))
+            }
+            state = .bufferingCloseTag(partialMatch.matched)
+            remaining = ""
+        } else {
+            thinkingContent += remaining
+            outputs.append(.thinkingChunk(remaining))
+            remaining = ""
+        }
+
+        return outputs
+    }
+
+    private func processBufferingCloseTag(buffer: String, remaining: inout String) -> [Output] {
+        var outputs: [Output] = []
+        let combined = buffer + remaining
+
+        if let tagRange = combined.range(of: closeTag) {
+            let before = String(combined[..<tagRange.lowerBound])
+            if !before.isEmpty {
+                thinkingContent += before
+                outputs.append(.thinkingChunk(before))
+            }
+            outputs.append(.thinkingEnd(thinkingContent))
+            state = .idle
+            thinkingContent = ""
+            remaining = String(combined[tagRange.upperBound...])
+        } else if closeTag.hasPrefix(combined) {
+            state = .bufferingCloseTag(combined)
+            remaining = ""
+        } else if let partialMatch = findPartialMatch(combined, target: closeTag) {
+            let before = String(combined[..<partialMatch.range.lowerBound])
+            if !before.isEmpty {
+                thinkingContent += before
+                outputs.append(.thinkingChunk(before))
+            }
+            state = .bufferingCloseTag(partialMatch.matched)
+            remaining = ""
+        } else {
+            thinkingContent += combined
+            outputs.append(.thinkingChunk(combined))
+            state = .inThinking
+            remaining = ""
+        }
+
+        return outputs
+    }
+
+    private func findPartialMatch(_ str: String, target: String) -> (range: Range<String.Index>, matched: String)? {
+        for i in 1..<target.count {
+            let suffix = String(str.suffix(i))
+            let prefix = String(target.prefix(i))
+            if suffix == prefix {
+                let startIndex = str.index(str.endIndex, offsetBy: -i)
+                return (startIndex..<str.endIndex, suffix)
+            }
+        }
+        return nil
+    }
+}

--- a/package/ios/Sources/ThinkingStateMachine.swift
+++ b/package/ios/Sources/ThinkingStateMachine.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class ThinkingStateMachine {
+struct ThinkingStateMachine {
     enum Output {
         case token(String)
         case thinkingStart
@@ -21,7 +21,7 @@ class ThinkingStateMachine {
     private let openTag = "<think>"
     private let closeTag = "</think>"
 
-    func process(token: String) -> [Output] {
+    mutating func process(token: String) -> [Output] {
         var outputs: [Output] = []
         var remaining = token
 
@@ -44,7 +44,7 @@ class ThinkingStateMachine {
         return outputs
     }
 
-    func flush() -> [Output] {
+    mutating func flush() -> [Output] {
         var outputs: [Output] = []
 
         switch state {
@@ -68,7 +68,7 @@ class ThinkingStateMachine {
         return outputs
     }
 
-    private func processIdle(_ remaining: inout String) -> [Output] {
+    private mutating func processIdle(_ remaining: inout String) -> [Output] {
         var outputs: [Output] = []
 
         if let tagRange = remaining.range(of: openTag) {
@@ -95,7 +95,7 @@ class ThinkingStateMachine {
         return outputs
     }
 
-    private func processBufferingOpenTag(buffer: String, remaining: inout String) -> [Output] {
+    private mutating func processBufferingOpenTag(buffer: String, remaining: inout String) -> [Output] {
         var outputs: [Output] = []
         let combined = buffer + remaining
 
@@ -127,7 +127,7 @@ class ThinkingStateMachine {
         return outputs
     }
 
-    private func processInThinking(_ remaining: inout String) -> [Output] {
+    private mutating func processInThinking(_ remaining: inout String) -> [Output] {
         var outputs: [Output] = []
 
         if let tagRange = remaining.range(of: closeTag) {
@@ -157,7 +157,7 @@ class ThinkingStateMachine {
         return outputs
     }
 
-    private func processBufferingCloseTag(buffer: String, remaining: inout String) -> [Output] {
+    private mutating func processBufferingCloseTag(buffer: String, remaining: inout String) -> [Output] {
         var outputs: [Output] = []
         let combined = buffer + remaining
 
@@ -193,7 +193,7 @@ class ThinkingStateMachine {
     }
 
     private func findPartialMatch(_ str: String, target: String) -> (range: Range<String.Index>, matched: String)? {
-        for i in 1..<target.count {
+        for i in stride(from: target.count - 1, through: 1, by: -1) {
             let suffix = String(str.suffix(i))
             let prefix = String(target.prefix(i))
             if suffix == prefix {

--- a/package/nitrogen/generated/ios/c++/HybridLLMSpecSwift.hpp
+++ b/package/nitrogen/generated/ios/c++/HybridLLMSpecSwift.hpp
@@ -125,6 +125,14 @@ namespace margelo::nitro::mlxreactnative {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline std::shared_ptr<Promise<std::string>> streamWithEvents(const std::string& prompt, const std::function<void(const std::string& /* eventJson */)>& onEvent) override {
+      auto __result = _swiftPart.streamWithEvents(prompt, onEvent);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline void stop() override {
       auto __result = _swiftPart.stop();
       if (__result.hasError()) [[unlikely]] {

--- a/package/nitrogen/generated/ios/swift/GenerationStats.swift
+++ b/package/nitrogen/generated/ios/swift/GenerationStats.swift
@@ -19,8 +19,8 @@ public extension GenerationStats {
   /**
    * Create a new instance of `GenerationStats`.
    */
-  init(tokenCount: Double, tokensPerSecond: Double, timeToFirstToken: Double, totalTime: Double) {
-    self.init(tokenCount, tokensPerSecond, timeToFirstToken, totalTime)
+  init(tokenCount: Double, tokensPerSecond: Double, timeToFirstToken: Double, totalTime: Double, toolExecutionTime: Double) {
+    self.init(tokenCount, tokensPerSecond, timeToFirstToken, totalTime, toolExecutionTime)
   }
 
   var tokenCount: Double {
@@ -64,6 +64,17 @@ public extension GenerationStats {
     @inline(__always)
     set {
       self.__totalTime = newValue
+    }
+  }
+  
+  var toolExecutionTime: Double {
+    @inline(__always)
+    get {
+      return self.__toolExecutionTime
+    }
+    @inline(__always)
+    set {
+      self.__toolExecutionTime = newValue
     }
   }
 }

--- a/package/nitrogen/generated/ios/swift/HybridLLMSpec.swift
+++ b/package/nitrogen/generated/ios/swift/HybridLLMSpec.swift
@@ -21,6 +21,7 @@ public protocol HybridLLMSpec_protocol: HybridObject {
   func load(modelId: String, options: LLMLoadOptions?) throws -> Promise<Void>
   func generate(prompt: String) throws -> Promise<String>
   func stream(prompt: String, onToken: @escaping (_ token: String) -> Void, onToolCall: ((_ toolName: String, _ args: String) -> Void)?) throws -> Promise<String>
+  func streamWithEvents(prompt: String, onEvent: @escaping (_ eventJson: String) -> Void) throws -> Promise<String>
   func stop() throws -> Void
   func unload() throws -> Void
   func getLastGenerationStats() throws -> GenerationStats

--- a/package/nitrogen/generated/ios/swift/HybridLLMSpec_cxx.swift
+++ b/package/nitrogen/generated/ios/swift/HybridLLMSpec_cxx.swift
@@ -233,6 +233,30 @@ open class HybridLLMSpec_cxx {
   }
   
   @inline(__always)
+  public final func streamWithEvents(prompt: std.string, onEvent: bridge.Func_void_std__string) -> bridge.Result_std__shared_ptr_Promise_std__string___ {
+    do {
+      let __result = try self.__implementation.streamWithEvents(prompt: String(prompt), onEvent: { () -> (String) -> Void in
+        let __wrappedFunction = bridge.wrap_Func_void_std__string(onEvent)
+        return { (__eventJson: String) -> Void in
+          __wrappedFunction.call(std.string(__eventJson))
+        }
+      }())
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_std__string__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_std__string__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_std__string__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve(std.string(__result)) })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_std__string___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_std__string___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func stop() -> bridge.Result_void_ {
     do {
       try self.__implementation.stop()

--- a/package/nitrogen/generated/shared/c++/GenerationStats.hpp
+++ b/package/nitrogen/generated/shared/c++/GenerationStats.hpp
@@ -38,10 +38,11 @@ namespace margelo::nitro::mlxreactnative {
     double tokensPerSecond     SWIFT_PRIVATE;
     double timeToFirstToken     SWIFT_PRIVATE;
     double totalTime     SWIFT_PRIVATE;
+    double toolExecutionTime     SWIFT_PRIVATE;
 
   public:
     GenerationStats() = default;
-    explicit GenerationStats(double tokenCount, double tokensPerSecond, double timeToFirstToken, double totalTime): tokenCount(tokenCount), tokensPerSecond(tokensPerSecond), timeToFirstToken(timeToFirstToken), totalTime(totalTime) {}
+    explicit GenerationStats(double tokenCount, double tokensPerSecond, double timeToFirstToken, double totalTime, double toolExecutionTime): tokenCount(tokenCount), tokensPerSecond(tokensPerSecond), timeToFirstToken(timeToFirstToken), totalTime(totalTime), toolExecutionTime(toolExecutionTime) {}
   };
 
 } // namespace margelo::nitro::mlxreactnative
@@ -57,7 +58,8 @@ namespace margelo::nitro {
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, "tokenCount")),
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, "tokensPerSecond")),
         JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, "timeToFirstToken")),
-        JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, "totalTime"))
+        JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, "totalTime")),
+        JSIConverter<double>::fromJSI(runtime, obj.getProperty(runtime, "toolExecutionTime"))
       );
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::mlxreactnative::GenerationStats& arg) {
@@ -66,6 +68,7 @@ namespace margelo::nitro {
       obj.setProperty(runtime, "tokensPerSecond", JSIConverter<double>::toJSI(runtime, arg.tokensPerSecond));
       obj.setProperty(runtime, "timeToFirstToken", JSIConverter<double>::toJSI(runtime, arg.timeToFirstToken));
       obj.setProperty(runtime, "totalTime", JSIConverter<double>::toJSI(runtime, arg.totalTime));
+      obj.setProperty(runtime, "toolExecutionTime", JSIConverter<double>::toJSI(runtime, arg.toolExecutionTime));
       return obj;
     }
     static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
@@ -80,6 +83,7 @@ namespace margelo::nitro {
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, "tokensPerSecond"))) return false;
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, "timeToFirstToken"))) return false;
       if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, "totalTime"))) return false;
+      if (!JSIConverter<double>::canConvert(runtime, obj.getProperty(runtime, "toolExecutionTime"))) return false;
       return true;
     }
   };

--- a/package/nitrogen/generated/shared/c++/HybridLLMSpec.cpp
+++ b/package/nitrogen/generated/shared/c++/HybridLLMSpec.cpp
@@ -24,6 +24,7 @@ namespace margelo::nitro::mlxreactnative {
       prototype.registerHybridMethod("load", &HybridLLMSpec::load);
       prototype.registerHybridMethod("generate", &HybridLLMSpec::generate);
       prototype.registerHybridMethod("stream", &HybridLLMSpec::stream);
+      prototype.registerHybridMethod("streamWithEvents", &HybridLLMSpec::streamWithEvents);
       prototype.registerHybridMethod("stop", &HybridLLMSpec::stop);
       prototype.registerHybridMethod("unload", &HybridLLMSpec::unload);
       prototype.registerHybridMethod("getLastGenerationStats", &HybridLLMSpec::getLastGenerationStats);

--- a/package/nitrogen/generated/shared/c++/HybridLLMSpec.hpp
+++ b/package/nitrogen/generated/shared/c++/HybridLLMSpec.hpp
@@ -69,6 +69,7 @@ namespace margelo::nitro::mlxreactnative {
       virtual std::shared_ptr<Promise<void>> load(const std::string& modelId, const std::optional<LLMLoadOptions>& options) = 0;
       virtual std::shared_ptr<Promise<std::string>> generate(const std::string& prompt) = 0;
       virtual std::shared_ptr<Promise<std::string>> stream(const std::string& prompt, const std::function<void(const std::string& /* token */)>& onToken, const std::optional<std::function<void(const std::string& /* toolName */, const std::string& /* args */)>>& onToolCall) = 0;
+      virtual std::shared_ptr<Promise<std::string>> streamWithEvents(const std::string& prompt, const std::function<void(const std::string& /* eventJson */)>& onEvent) = 0;
       virtual void stop() = 0;
       virtual void unload() = 0;
       virtual GenerationStats getLastGenerationStats() = 0;

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,4 +1,10 @@
-export { LLM, type Message, type ToolCallInfo, type ToolCallUpdate } from './llm'
+export {
+  LLM,
+  type EventCallback,
+  type Message,
+  type ToolCallInfo,
+  type ToolCallUpdate,
+} from './llm'
 export { ModelManager } from './modelManager'
 export {
   MLXModel,
@@ -12,6 +18,17 @@ export type {
   GenerationStats,
   LLM as LLMSpec,
   LLMLoadOptions,
+  StreamEvent,
+  GenerationStartEvent,
+  TokenEvent,
+  ThinkingStartEvent,
+  ThinkingChunkEvent,
+  ThinkingEndEvent,
+  ToolCallStartEvent,
+  ToolCallExecutingEvent,
+  ToolCallCompletedEvent,
+  ToolCallFailedEvent,
+  GenerationEndEvent,
   ToolDefinition,
   ToolParameter,
   ToolParameterType,

--- a/package/src/llm.ts
+++ b/package/src/llm.ts
@@ -1,5 +1,12 @@
 import { NitroModules } from 'react-native-nitro-modules'
-import type { GenerationStats, LLMLoadOptions, LLM as LLMSpec } from './specs/LLM.nitro'
+import type {
+  GenerationStats,
+  LLMLoadOptions,
+  LLM as LLMSpec,
+  StreamEvent,
+} from './specs/LLM.nitro'
+
+export type EventCallback = (event: StreamEvent) => void
 
 let instance: LLMSpec | null = null
 
@@ -102,6 +109,45 @@ export const LLM = {
             allToolCalls: [...accumulatedToolCalls],
           })
         }
+      }
+    })
+  },
+
+  /**
+   * Stream with typed events for thinking blocks and tool calls.
+   * Provides granular lifecycle events for UI updates.
+   *
+   * @param prompt - The input text
+   * @param onEvent - Callback receiving typed StreamEvent objects
+   * @returns Promise resolving to final content string (thinking content stripped)
+   *
+   * @example
+   * ```ts
+   * await LLM.streamWithEvents(prompt, (event) => {
+   *   switch (event.type) {
+   *     case 'token':
+   *       appendToContent(event.token)
+   *       break
+   *     case 'thinking_start':
+   *       showThinkingIndicator()
+   *       break
+   *     case 'thinking_chunk':
+   *       appendToThinking(event.chunk)
+   *       break
+   *     case 'tool_call_start':
+   *       showToolCallCard(event.name, event.arguments)
+   *       break
+   *   }
+   * })
+   * ```
+   */
+  streamWithEvents(prompt: string, onEvent: EventCallback): Promise<string> {
+    return getInstance().streamWithEvents(prompt, (eventJson: string) => {
+      try {
+        const event = JSON.parse(eventJson) as StreamEvent
+        onEvent(event)
+      } catch {
+        // Silently ignore malformed events
       }
     })
   },

--- a/package/src/llm.ts
+++ b/package/src/llm.ts
@@ -169,7 +169,7 @@ export const LLM = {
 
   /**
    * Get statistics from the last generation.
-   * @returns Statistics including token count, tokens/sec, TTFT, and total time
+   * @returns Statistics including token count, tokens/sec (excluding tool execution), TTFT, total time, and tool execution time
    */
   getLastGenerationStats(): GenerationStats {
     return getInstance().getLastGenerationStats()

--- a/package/src/specs/LLM.nitro.ts
+++ b/package/src/specs/LLM.nitro.ts
@@ -4,15 +4,79 @@ import type { AnyMap, HybridObject } from 'react-native-nitro-modules'
  * Statistics from the last text generation.
  */
 export interface GenerationStats {
-  /** Total number of tokens generated */
   tokenCount: number
-  /** Generation speed in tokens per second */
   tokensPerSecond: number
-  /** Time in milliseconds until the first token was generated */
   timeToFirstToken: number
-  /** Total generation time in milliseconds */
   totalTime: number
 }
+
+export interface GenerationStartEvent {
+  type: 'generation_start'
+  timestamp: number
+}
+
+export interface TokenEvent {
+  type: 'token'
+  token: string
+}
+
+export interface ThinkingStartEvent {
+  type: 'thinking_start'
+  timestamp: number
+}
+
+export interface ThinkingChunkEvent {
+  type: 'thinking_chunk'
+  chunk: string
+}
+
+export interface ThinkingEndEvent {
+  type: 'thinking_end'
+  content: string
+  timestamp: number
+}
+
+export interface ToolCallStartEvent {
+  type: 'tool_call_start'
+  id: string
+  name: string
+  arguments: string
+}
+
+export interface ToolCallExecutingEvent {
+  type: 'tool_call_executing'
+  id: string
+}
+
+export interface ToolCallCompletedEvent {
+  type: 'tool_call_completed'
+  id: string
+  result: string
+}
+
+export interface ToolCallFailedEvent {
+  type: 'tool_call_failed'
+  id: string
+  error: string
+}
+
+export interface GenerationEndEvent {
+  type: 'generation_end'
+  content: string
+  stats: GenerationStats
+}
+
+export type StreamEvent =
+  | GenerationStartEvent
+  | TokenEvent
+  | ThinkingStartEvent
+  | ThinkingChunkEvent
+  | ThinkingEndEvent
+  | ToolCallStartEvent
+  | ToolCallExecutingEvent
+  | ToolCallCompletedEvent
+  | ToolCallFailedEvent
+  | GenerationEndEvent
 
 export interface LLMMessage {
   role: string
@@ -83,6 +147,11 @@ export interface LLM extends HybridObject<{ ios: 'swift' }> {
     prompt: string,
     onToken: (token: string) => void,
     onToolCall?: (toolName: string, args: string) => void,
+  ): Promise<string>
+
+  streamWithEvents(
+    prompt: string,
+    onEvent: (eventJson: string) => void,
   ): Promise<string>
 
   /**

--- a/package/src/specs/LLM.nitro.ts
+++ b/package/src/specs/LLM.nitro.ts
@@ -8,6 +8,7 @@ export interface GenerationStats {
   tokensPerSecond: number
   timeToFirstToken: number
   totalTime: number
+  toolExecutionTime: number
 }
 
 export interface GenerationStartEvent {


### PR DESCRIPTION
## Summary
- Add `streamWithEvents` API that emits typed stream events (thinking, text, generation stats) during LLM generation, powered by a Swift thinking state machine
- Implement `StreamEventEmitter` and `ThinkingStateMachine` on the native side to parse and classify streamed tokens into thinking vs text content
- Add TypeScript wrapper with typed event definitions and update Nitro spec with new `StreamEvent` types

## Test plan
- [x] Run the example app and verify `streamWithEvents` produces correct thinking/text events
- [x] Verify generation stats event fires at end of stream
- [x] Confirm benchmark still works correctly after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)