### PR TITLE
Bump default tokenBatchSize from 1 to 4

### DIFF
--- a/package/ios/Sources/HybridLLM.swift
+++ b/package/ios/Sources/HybridLLM.swift
@@ -59,7 +59,7 @@ class HybridLLM: HybridLLMSpec {
     private var tools: [ToolDefinition] = []
     private var toolSchemas: [ToolSpec] = []
     private var generationParameters: GenerateParameters = GenerateParameters()
-    private var tokenBatchSize: Int = 1
+    private var tokenBatchSize: Int = 4
     private var contextConfig: LLMContextConfig?
 
     var isLoaded: Bool { container != nil }
@@ -432,7 +432,7 @@ class HybridLLM: HybridLLMSpec {
                 messageHistory = []
                 manageHistory = false
                 generationParameters = GenerateParameters()
-                tokenBatchSize = 1
+                tokenBatchSize = 4
                 contextConfig = nil
                 self.modelId = ""
                 Memory.clearCache()
@@ -472,7 +472,7 @@ class HybridLLM: HybridLLMSpec {
                 }
 
                 generationParameters = buildGenerateParameters(from: options?.generationConfig)
-                tokenBatchSize = normalizedInt(options?.tokenBatchSize, minimum: 1) ?? 1
+                tokenBatchSize = normalizedInt(options?.tokenBatchSize, minimum: 1) ?? 4
                 contextConfig = options?.contextConfig
 
                 self.container = loadedContainer
@@ -1162,7 +1162,7 @@ class HybridLLM: HybridLLMSpec {
         messageHistory = []
         manageHistory = false
         generationParameters = GenerateParameters()
-        tokenBatchSize = 1
+        tokenBatchSize = 4
         contextConfig = nil
         modelId = ""
 


### PR DESCRIPTION
## Summary
- Raise the default `tokenBatchSize` from `1` to `4` in `HybridLLM` so streaming emits ~4× fewer `TokenEvent`s, JSON encodes, and JS bridge crossings out of the box, with negligible chunking at typical on-device generation speeds.
- Update all three default sites (property initializer, `load()` reset, `unload()` reset) plus the fallback when `options.tokenBatchSize` is omitted.

## Test plan
- [x] Stream a long response in the example app and confirm typewriter UX still feels smooth
- [x] Verify explicit `tokenBatchSize: 1` still produces per-token events
- [x] Verify explicit `tokenBatchSize: 8` still produces 8-token batches