### PR TITLE
Remove hardcoded Memory.cacheLimit override in load

### DIFF
--- a/package/ios/Sources/HybridLLM.swift
+++ b/package/ios/Sources/HybridLLM.swift
@@ -705,8 +705,6 @@ private final class HybridLLMCore {
         loadTask?.cancel()
 
         let task = Task { @MainActor in
-            Memory.cacheLimit = 2_000_000
-
             currentTask?.cancel()
             currentTask = nil
             session = nil


### PR DESCRIPTION
## Summary
- Drop the `Memory.cacheLimit = 2_000_000` assignment from `HybridLLMCore` load path in `package/ios/Sources/HybridLLM.swift`
- Defer to MLX's default cache limit rather than forcing a fixed 2MB ceiling on every load
