### PR TITLE
feat(tts): support configurable speech speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ const final = await STT.stopListening()      // Stop and get final transcript
 | Property | Type | Description |
 |----------|------|-------------|
 | `voice` | `string` | Voice to use (alba, azelma, cosette, eponine, fantine, javert, jean, marius) |
-| `speed` | `number` | Speech speed multiplier |
+| `speed` | `number` | Speech speed multiplier (`0.5`–`2.0`, default `1.0`). Currently uses linear resampling, so pitch changes with speed. |
 
 | Property | Description |
 |----------|-------------|

--- a/package/ios/Sources/HybridTTS.swift
+++ b/package/ios/Sources/HybridTTS.swift
@@ -20,15 +20,23 @@ class HybridTTS: HybridTTSSpec {
     Double(model?.sampleRate ?? 24000)
   }
 
-  private func mlxArrayToArrayBuffer(_ audio: MLXArray) -> ArrayBuffer {
+  private func mlxArrayToArrayBuffer(
+    _ audio: MLXArray,
+    speed: TTSSpeed,
+    outputSampleCount: Int? = nil
+  ) -> ArrayBuffer {
     let evaluated = audio.asType(.float32)
     MLX.eval(evaluated)
-    let arrayData = evaluated.asData(access: .copy)
-    let byteSize = arrayData.data.count
+    let samples = speed.adjustSpeed(
+      evaluated.asArray(Float.self),
+      outputSampleCount: outputSampleCount
+    )
+    let byteSize = samples.count * MemoryLayout<Float>.size
     let buffer = ArrayBuffer.allocate(size: byteSize)
-    arrayData.data.withUnsafeBytes { srcPtr in
+    samples.withUnsafeBytes { srcPtr in
+      guard byteSize > 0, let source = srcPtr.baseAddress else { return }
       UnsafeMutableRawPointer(buffer.data).copyMemory(
-        from: srcPtr.baseAddress!,
+        from: source,
         byteCount: byteSize
       )
     }
@@ -45,7 +53,7 @@ class HybridTTS: HybridTTSSpec {
         self.model = nil
         MLX.Memory.clearCache()
 
-        let loadedModel = try await TTSModelUtils.loadModel(modelRepo: modelId)
+        let loadedModel = try await TTS.loadModel(modelRepo: modelId)
 
         try Task.checkCancellation()
 
@@ -67,6 +75,7 @@ class HybridTTS: HybridTTSSpec {
     guard let model else {
       throw TTSError.notLoaded
     }
+    let speed = try TTSSpeed(options?.speed)
 
     return Promise.async { [self] in
       let task = Task<Any, Error> {
@@ -77,7 +86,7 @@ class HybridTTS: HybridTTSSpec {
           refText: nil,
           language: nil
         )
-        return self.mlxArrayToArrayBuffer(audio) as Any
+        return self.mlxArrayToArrayBuffer(audio, speed: speed) as Any
       }
 
       self.activeTask = task
@@ -95,9 +104,11 @@ class HybridTTS: HybridTTSSpec {
     guard let model else {
       throw TTSError.notLoaded
     }
+    let speed = try TTSSpeed(options?.speed)
 
     return Promise.async { [self] in
       let task = Task<Any, Error> {
+        var speedPlanner = TTSStreamSpeedPlanner(speed: speed)
         let stream = model.generateStream(
           text: text,
           voice: options?.voice,
@@ -112,7 +123,15 @@ class HybridTTS: HybridTTSSpec {
 
           switch event {
           case .audio(let audio):
-            let buffer = self.mlxArrayToArrayBuffer(audio)
+            let outputSampleCount = speedPlanner.outputSampleCount(
+              for: audio.dim(0)
+            )
+            guard outputSampleCount > 0 else { continue }
+            let buffer = self.mlxArrayToArrayBuffer(
+              audio,
+              speed: speed,
+              outputSampleCount: outputSampleCount
+            )
             onAudioChunk(buffer)
           case .progress(let value):
             options?.onProgress?(value)

--- a/package/ios/Sources/TTSSpeed.swift
+++ b/package/ios/Sources/TTSSpeed.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+enum TTSSpeedError: Error, LocalizedError {
+  case unsupported(Double)
+
+  var errorDescription: String? {
+    switch self {
+    case .unsupported(let speed):
+      return "TTS speed must be between \(TTSSpeed.minimum) and \(TTSSpeed.maximum). Received \(speed)."
+    }
+  }
+}
+
+struct TTSSpeed {
+  static let minimum = 0.5
+  static let maximum = 2.0
+
+  let multiplier: Float
+
+  init(_ value: Double?) throws {
+    let value = value ?? 1.0
+    guard value.isFinite, value >= Self.minimum, value <= Self.maximum else {
+      throw TTSSpeedError.unsupported(value)
+    }
+    self.multiplier = Float(value)
+  }
+
+  func outputSampleCount(for inputSampleCount: Int) -> Int {
+    guard inputSampleCount > 0 else { return 0 }
+    return max(1, Int(Float(inputSampleCount) / multiplier))
+  }
+
+  func adjustSpeed(
+    _ samples: [Float],
+    outputSampleCount: Int? = nil
+  ) -> [Float] {
+    guard !samples.isEmpty else { return [] }
+
+    let outputSampleCount = outputSampleCount
+      ?? self.outputSampleCount(for: samples.count)
+    guard outputSampleCount > 0 else { return [] }
+    guard outputSampleCount != samples.count else { return samples }
+    guard outputSampleCount > 1 else { return [samples[0]] }
+
+    let inputLastIndex = samples.count - 1
+    let positionScale = Float(inputLastIndex) / Float(outputSampleCount - 1)
+    return (0..<outputSampleCount).map { outputIndex in
+      let position = Float(outputIndex) * positionScale
+      let leftIndex = Int(floor(position))
+      let rightIndex = min(leftIndex + 1, inputLastIndex)
+      let rightWeight = position - Float(leftIndex)
+      let leftWeight = 1 - rightWeight
+      return leftWeight * samples[leftIndex] + rightWeight * samples[rightIndex]
+    }
+  }
+}
+
+/// Carries fractional sample-count rounding across streamed chunks so streaming
+/// and one-shot synthesis have the same total duration.
+struct TTSStreamSpeedPlanner {
+  private let speed: TTSSpeed
+  private var totalInputSampleCount = 0
+  private var totalOutputSampleCount = 0
+
+  init(speed: TTSSpeed) {
+    self.speed = speed
+  }
+
+  mutating func outputSampleCount(for inputSampleCount: Int) -> Int {
+    guard inputSampleCount > 0 else { return 0 }
+
+    totalInputSampleCount += inputSampleCount
+    let targetTotal = speed.outputSampleCount(for: totalInputSampleCount)
+    let chunkOutputSampleCount = targetTotal - totalOutputSampleCount
+    totalOutputSampleCount = targetTotal
+    return chunkOutputSampleCount
+  }
+}

--- a/package/ios/Tests/TTSSpeedTests.swift
+++ b/package/ios/Tests/TTSSpeedTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+private enum TestFailure: Error {
+  case failed(String)
+}
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+  if !condition() {
+    throw TestFailure.failed(message)
+  }
+}
+
+private func expectSamples(
+  _ actual: [Float],
+  _ expected: [Float],
+  _ message: String
+) throws {
+  try expect(actual.count == expected.count, "\(message) sample count")
+  for (index, pair) in zip(actual, expected).enumerated() {
+    try expect(
+      abs(pair.0 - pair.1) < 0.0001,
+      "\(message) sample \(index): expected \(pair.1), received \(pair.0)"
+    )
+  }
+}
+
+@main
+struct TTSSpeedTests {
+  static func main() throws {
+    let sampleRate = 24_000
+    let inputSampleCount = sampleRate
+    let slow = try TTSSpeed(0.5)
+    let normal = try TTSSpeed(1.0)
+    let fast = try TTSSpeed(2.0)
+
+    let slowDuration = Double(slow.outputSampleCount(for: inputSampleCount)) / Double(sampleRate)
+    let normalDuration = Double(normal.outputSampleCount(for: inputSampleCount)) / Double(sampleRate)
+    let fastDuration = Double(fast.outputSampleCount(for: inputSampleCount)) / Double(sampleRate)
+
+    try expect(slowDuration == 2.0, "slow output duration")
+    try expect(normalDuration == 1.0, "normal output duration")
+    try expect(fastDuration == 0.5, "fast output duration")
+    try expect(slowDuration > normalDuration, "slow must be longer than normal")
+    try expect(normalDuration > fastDuration, "normal must be longer than fast")
+
+    let inputSamples: [Float] = [0, 7, 14, 21]
+    try expectSamples(
+      slow.adjustSpeed(inputSamples),
+      [0, 3, 6, 9, 12, 15, 18, 21],
+      "slow interpolation"
+    )
+    try expectSamples(
+      normal.adjustSpeed(inputSamples),
+      inputSamples,
+      "normal interpolation"
+    )
+    try expectSamples(
+      fast.adjustSpeed(inputSamples),
+      [0, 21],
+      "fast interpolation"
+    )
+
+    let streamedInputChunks = [7_777, 8_888, 7_335]
+    for speed in [slow, normal, fast] {
+      var planner = TTSStreamSpeedPlanner(speed: speed)
+      let streamedOutputSampleCount = streamedInputChunks.reduce(into: 0) { total, chunk in
+        total += planner.outputSampleCount(for: chunk)
+      }
+      try expect(
+        streamedOutputSampleCount == speed.outputSampleCount(for: inputSampleCount),
+        "streaming and one-shot output durations must match at speed \(speed.multiplier)"
+      )
+    }
+
+    for unsupportedSpeed in [0.0, 0.49, 2.01, Double.infinity, Double.nan] {
+      do {
+        _ = try TTSSpeed(unsupportedSpeed)
+        throw TestFailure.failed("unsupported speed \(unsupportedSpeed) was accepted")
+      } catch is TTSSpeedError {
+        // Expected.
+      }
+    }
+  }
+}

--- a/package/package.json
+++ b/package/package.json
@@ -14,6 +14,7 @@
     "test:ios-history-trim": "swiftc ios/Sources/ManagedHistoryTrimPlanner.swift ios/Tests/ManagedHistoryTrimPlannerSpyTests.swift -o /tmp/ManagedHistoryTrimPlannerSpyTests && /tmp/ManagedHistoryTrimPlannerSpyTests",
     "test:ios-llm-error": "swiftc ios/Sources/LLMError.swift ios/Tests/LLMErrorTests.swift -o /tmp/LLMErrorTests && /tmp/LLMErrorTests",
     "test:ios-generation-task": "swiftc ios/Sources/LLMError.swift ios/Sources/GenerationTaskController.swift ios/Tests/GenerationTaskControllerTests.swift -o /tmp/GenerationTaskControllerTests && /tmp/GenerationTaskControllerTests",
+    "test:ios-tts-speed": "swiftc ios/Sources/TTSSpeed.swift ios/Tests/TTSSpeedTests.swift -o /tmp/TTSSpeedTests && /tmp/TTSSpeedTests",
     "clean": "rm -rf android/build node_modules/**/android/build lib android/.cxx node_modules/**/android/.cxx",
     "release": "release-it",
     "specs": "bun typecheck && nitrogen --logLevel=\\\"debug\\\" && bun run build",

--- a/package/src/runtime.test.ts
+++ b/package/src/runtime.test.ts
@@ -6,6 +6,8 @@ import {
   createSafeCallback,
   mapStreamEventEnvelope,
   safeJsonParse,
+  TTS_MAX_SPEED,
+  TTS_MIN_SPEED,
   validateLLMLoadOptions,
   validateTTSGenerateOptions,
 } from './runtime'
@@ -71,8 +73,24 @@ describe('runtime guards', () => {
   })
 
   it('rejects invalid TTS generation options', () => {
-    expect(() => validateTTSGenerateOptions({ speed: 0 })).toThrow(
-      'must be a positive finite number',
+    expect(() => validateTTSGenerateOptions({ speed: TTS_MIN_SPEED - 0.01 })).toThrow(
+      'must be between 0.5 and 2',
+    )
+    expect(() => validateTTSGenerateOptions({ speed: TTS_MAX_SPEED + 0.01 })).toThrow(
+      'must be between 0.5 and 2',
+    )
+    expect(() => validateTTSGenerateOptions({ speed: Number.POSITIVE_INFINITY })).toThrow(
+      'must be between 0.5 and 2',
+    )
+    expect(() => validateTTSGenerateOptions({ speed: Number.NaN })).toThrow(
+      'must be between 0.5 and 2',
+    )
+    expect(validateTTSGenerateOptions({ speed: TTS_MIN_SPEED })?.speed).toBe(
+      TTS_MIN_SPEED,
+    )
+    expect(validateTTSGenerateOptions({ speed: 1 })?.speed).toBe(1)
+    expect(validateTTSGenerateOptions({ speed: TTS_MAX_SPEED })?.speed).toBe(
+      TTS_MAX_SPEED,
     )
     expect(() => validateTTSGenerateOptions({ voice: '   ' })).toThrow(
       'must be a non-empty string',

--- a/package/src/runtime.ts
+++ b/package/src/runtime.ts
@@ -10,6 +10,8 @@ import type { STTLoadOptions } from './specs/STT.nitro'
 import type { TTSGenerateOptions, TTSLoadOptions } from './specs/TTS.nitro'
 
 const ERROR_PREFIX = '[react-native-nitro-mlx]'
+export const TTS_MIN_SPEED = 0.5
+export const TTS_MAX_SPEED = 2
 const runtimeConsole = (
   globalThis as { console?: { error?: (...args: unknown[]) => void } }
 ).console
@@ -158,8 +160,14 @@ export function validateTTSGenerateOptions(
   }
 
   if (options.speed !== undefined) {
-    if (!Number.isFinite(options.speed) || options.speed <= 0) {
-      throw new RangeError(`${ERROR_PREFIX} TTS speed must be a positive finite number.`)
+    if (
+      !Number.isFinite(options.speed) ||
+      options.speed < TTS_MIN_SPEED ||
+      options.speed > TTS_MAX_SPEED
+    ) {
+      throw new RangeError(
+        `${ERROR_PREFIX} TTS speed must be between ${TTS_MIN_SPEED} and ${TTS_MAX_SPEED}.`,
+      )
     }
   }
 

--- a/package/src/specs/TTS.nitro.ts
+++ b/package/src/specs/TTS.nitro.ts
@@ -6,6 +6,10 @@ export interface TTSLoadOptions {
 
 export interface TTSGenerateOptions {
   voice?: string
+  /**
+   * Speech-rate multiplier. Supported range is 0.5 (slowest) through 2.0 (fastest).
+   * Currently implemented with linear resampling, so pitch changes with speech rate.
+   */
   speed?: number
   /**
    * Fractional generation progress (0-1). Only fires during `stream()`, and only for


### PR DESCRIPTION
## Summary

- Add configurable TTS speed from 0.5x to 2.0x.
- Apply speed changes to one-shot and streamed audio generation.
- Validate supported speed values and document pitch changes from linear resampling.
- Add Swift and runtime tests for speed scaling and invalid input.

## Testing

- `bun test package/src/runtime.test.ts`
- `bun run test:ios-tts-speed`